### PR TITLE
Remove Trello link (we've migrated to GitHub Issues)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,5 @@ Refer to links in the file itself to learn about its configuration options, and 
 5. If you need to access the server from other devices, use `--host 0.0.0.0`.
 
 ## Private Resources
-- [Trello Board](https://trello.com/b/hK0hhEDy/dana-s-website)
 - [Google Analytics](https://analytics.google.com/analytics/web/#report/defaultid/a51703743w83996550p87034958/)
 - [Google Search Console](https://www.google.com/webmasters/tools/dashboard?siteUrl=http%3A%2F%2Fdanamccurdy.com%2F)


### PR DESCRIPTION
Merging this after I confirm the migration is done.